### PR TITLE
Fix log4j loading and trinidad stop

### DIFF
--- a/lib/trinidad_scheduler_extension/scheduler_extension.rb
+++ b/lib/trinidad_scheduler_extension/scheduler_extension.rb
@@ -4,6 +4,8 @@ module Trinidad
     class SchedulerWebAppExtension < WebAppExtension
       
       def configure(tomcat, app_context)
+        TrinidadScheduler.trinidad_scheduler_init_log4j
+
         app_context.add_lifecycle_listener(TrinidadScheduler::WebAppListener.new(app_context.servlet_context, @options))
       end
     end
@@ -11,6 +13,8 @@ module Trinidad
     class SchedulerServerExtension < ServerExtension
       
       def configure(tomcat)
+        TrinidadScheduler.trinidad_scheduler_init_log4j
+
         tomcat.get_host.add_container_listener(TrinidadScheduler::GlobalListener.new(@options))
       end
     end

--- a/lib/trinidad_scheduler_extension/scheduler_listener.rb
+++ b/lib/trinidad_scheduler_extension/scheduler_listener.rb
@@ -12,6 +12,10 @@ module TrinidadScheduler
       TrinidadScheduler.scheduler_exists?(@servlet_context) && !TrinidadScheduler[@servlet_context].is_started
     end
     
+    def is_started?
+      TrinidadScheduler.scheduler_exists?(@servlet_context) && TrinidadScheduler[@servlet_context].is_started
+    end
+    
     def lifecycle_event(event)
       case event.type
       when org.apache.catalina.Lifecycle::START_EVENT then
@@ -22,7 +26,7 @@ module TrinidadScheduler
         
         TrinidadScheduler.set_servlet_started(@servlet_context)
       when org.apache.catalina.Lifecycle::STOP_EVENT then
-        TrinidadScheduler[@servlet_context].shutdown if TrinidadScheduler.scheduler_exists?(@servlet_context) && TrinidadScheduler[@servlet_context].is_started
+        TrinidadScheduler[@servlet_context].shutdown if is_started?
       end
     end
   end

--- a/lib/trinidad_scheduler_extension/scheduler_listener.rb
+++ b/lib/trinidad_scheduler_extension/scheduler_listener.rb
@@ -21,6 +21,8 @@ module TrinidadScheduler
         end
         
         TrinidadScheduler.set_servlet_started(@servlet_context)
+      when org.apache.catalina.Lifecycle::STOP_EVENT then
+        TrinidadScheduler[@servlet_context].shutdown if TrinidadScheduler.scheduler_exists?(@servlet_context) && TrinidadScheduler[@servlet_context].is_started
       end
     end
   end

--- a/lib/trinidad_scheduler_extension/trinidad_scheduler.rb
+++ b/lib/trinidad_scheduler_extension/trinidad_scheduler.rb
@@ -1,6 +1,6 @@
 module TrinidadScheduler
-  CONFIG_HOME = File.expand_path(File.dirname(__FILE__) + "/trinidad_scheduler_extension/config")
-  JAR_HOME = File.expand_path(File.dirname(__FILE__) + "/trinidad_scheduler_extension/jars")
+  CONFIG_HOME = File.expand_path(File.dirname(__FILE__) + "/config")
+  JAR_HOME = File.expand_path(File.dirname(__FILE__) + "/jars")
   
   # Sets log4j properties if not established by Application Servers
   # TrinidadScheduler is really lazy so this is only set when a scheduler is needed


### PR DESCRIPTION
The scheduler extension did not handle the tomcat stop event properly which caused trinidad not to stop if schedulers were running. Handling the lifecycle STOP_EVENT fixes this, albeit tomcat still warns about memory leaks.

The log4j supplied properties file was not found, which caused trinidad to stop logging at all. I just fixed the path so it gets used. Problem still seems to be that now only the settings defined in the properties file of the extension are used.
