### PR TITLE
isStateful() returns the right value based on the job

### DIFF
--- a/lib/trinidad_scheduler_extension/job_detail.rb
+++ b/lib/trinidad_scheduler_extension/job_detail.rb
@@ -10,6 +10,10 @@ module TrinidadScheduler
       @job = job_class.new
     end
     
+    def isStateful()
+      @job.is_a?(org.quartz.StatefulJob)
+    end
+
     def validate()
       raise org.quartz.SchedulerException.new("Job's name cannot be null",
         org.quartz.SchedulerException.ERR_CLIENT_ERROR) if get_name == nil


### PR DESCRIPTION
This way it's possible to create stateful jobs where the job executions can't overlap.
